### PR TITLE
chore(cms): add vercel bootstrap placeholder

### DIFF
--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -1,0 +1,6 @@
+# CMS Bootstrap
+
+This directory is a temporary static placeholder so Vercel can create a project
+with `apps/cms` as its root directory.
+
+The real CMS application should replace these files in a follow-up PR.

--- a/apps/cms/index.html
+++ b/apps/cms/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zivoe CMS Bootstrap</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #f4f1ea;
+        color: #10261d;
+      }
+
+      main {
+        width: min(560px, calc(100vw - 48px));
+        padding: 32px;
+        border: 1px solid #d7d0c4;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.84);
+        box-shadow: 0 16px 40px rgba(16, 38, 29, 0.08);
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        font-size: 2rem;
+        line-height: 1.1;
+      }
+
+      p {
+        margin: 0;
+        line-height: 1.6;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Zivoe CMS bootstrap</h1>
+      <p>
+        This placeholder exists so the monorepo can be connected to a dedicated
+        Vercel project at <code>apps/cms</code> before the real CMS app lands.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Add a minimal static placeholder at apps/cms so a dedicated Vercel project can be created before the real CMS application is introduced.