### PR TITLE
feat: add more posthog events

### DIFF
--- a/apps/dapp/src/app/(auth)/onboarding/page.tsx
+++ b/apps/dapp/src/app/(auth)/onboarding/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from 'next/navigation';
+import { after } from 'next/server';
 
 import { getOnboardedStatus } from '@/server/data/auth';
+import { captureServerEvent } from '@/server/utils/analytics';
 
 import OnboardingForm from './_components/onboarding-form';
 
@@ -9,6 +11,13 @@ export default async function OnboardingPage() {
 
   if (!user) redirect('/sign-in');
   if (isOnboarded) redirect('/');
+
+  after(() =>
+    captureServerEvent({
+      distinctId: user.id,
+      event: 'onboarding:started'
+    })
+  );
 
   return (
     <div className="flex h-full flex-col items-center">

--- a/apps/dapp/src/app/(auth)/sign-in/_components/sign-in-form.tsx
+++ b/apps/dapp/src/app/(auth)/sign-in/_components/sign-in-form.tsx
@@ -20,6 +20,7 @@ import { ArrowLeftIcon, GoogleIcon, TwitterIcon } from '@zivoe/ui/icons';
 
 import { WITH_TURNSTILE } from '@/types/constants';
 
+import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { authClient } from '@/lib/auth-client';
 import { handlePromise } from '@/lib/utils';
 
@@ -123,6 +124,7 @@ function EmailStepForm({
   onSuccess: (data: EmailFormData) => void;
   executeTurnstile: () => Promise<string>;
 }) {
+  const analytics = useAnalytics();
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
   const [isTwitterLoading, setIsTwitterLoading] = useState(false);
 
@@ -189,6 +191,7 @@ function EmailStepForm({
       return;
     }
 
+    analytics.capture('auth:otp_requested', { method: 'email_otp' });
     onSuccess({ email });
   };
 
@@ -267,6 +270,7 @@ const otpSchema = z.object({
 type OtpFormData = z.infer<typeof otpSchema>;
 
 function OtpStepForm({ email, executeTurnstile }: { email: string; executeTurnstile: () => Promise<string> }) {
+  const analytics = useAnalytics();
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [isResending, setIsResending] = useState(false);
@@ -345,6 +349,8 @@ function OtpStepForm({ email, executeTurnstile }: { email: string; executeTurnst
 
       Sentry.captureException(error, { tags: { source: 'SERVER', flow: 'resend-otp' } });
     } else {
+      analytics.capture('auth:otp_resent', { method: 'email_otp' });
+
       toast({
         title: 'Code sent',
         description: 'A new verification code has been sent to your email',

--- a/apps/dapp/src/app/(auth)/sign-in/_hooks/useTurnstile.ts
+++ b/apps/dapp/src/app/(auth)/sign-in/_hooks/useTurnstile.ts
@@ -20,7 +20,7 @@ export const useTurnstile = () => {
         turnstileRef.current?.reset();
         turnstileRef.current?.execute();
       } catch (error) {
-        reject(error as Error);
+        reject(error instanceof Error ? error : new Error(String(error)));
       }
     });
   }

--- a/apps/dapp/src/app/(dashboard)/home/deposit/_hooks/useRedeemUSDC.ts
+++ b/apps/dapp/src/app/(dashboard)/home/deposit/_hooks/useRedeemUSDC.ts
@@ -7,6 +7,8 @@ import { type WriteContractParameters } from 'wagmi/actions';
 import { CONTRACTS } from '@zivoe/contracts';
 import { ocrCycleV2Abi } from '@zivoe/contracts/abis';
 
+import { createTransactionProperties, getAnalyticsErrorType } from '@/lib/analytics/events';
+import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { queryKeys } from '@/lib/query-keys';
 import { type TransactionData, depositDialogAtom, transactionAtom } from '@/lib/store';
 import { AppError, onTxError, skipTxSettled } from '@/lib/utils';
@@ -20,6 +22,7 @@ export type RedeemUSDCParams = WriteContractParameters<typeof ocrCycleV2Abi, 're
 
 export const useRedeemUSDC = () => {
   const { address } = useAccount();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const { simulateTx, sendTx, waitForTxReceipt, isTxPending } = useTx();
   const setTransaction = useSetAtom(transactionAtom);
@@ -29,6 +32,15 @@ export const useRedeemUSDC = () => {
     mutationFn: async ({ amount }: { amount?: bigint }) => {
       if (!amount || amount === 0n) throw new AppError({ message: 'No amount to redeem' });
 
+      const baseAnalyticsInput = {
+        flow: 'redeem',
+        step: 'submitted',
+        walletAddress: address,
+        tokenIn: 'zVLT',
+        tokenOut: 'USDC',
+        amountInRaw: amount
+      } as const;
+
       const params: RedeemUSDCParams & SimulateContractParameters = {
         abi: ocrCycleV2Abi,
         address: CONTRACTS.OCR_CycleV2,
@@ -36,16 +48,46 @@ export const useRedeemUSDC = () => {
         args: [amount]
       };
 
-      await simulateTx(params);
+      let txHash: `0x${string}` | undefined;
 
-      const { hash } = await sendTx(params);
+      try {
+        await simulateTx(params);
 
-      const receipt = await waitForTxReceipt({
-        hash,
-        messages: { pending: 'Redeeming zVLT...' }
-      });
+        const { hash } = await sendTx(params);
+        txHash = hash;
+        analytics.capture('tx:redeem_submitted', createTransactionProperties({ ...baseAnalyticsInput, txHash }));
 
-      return { receipt, amount };
+        const receipt = await waitForTxReceipt({
+          hash,
+          messages: { pending: 'Redeeming zVLT...' }
+        });
+
+        analytics.capture(
+          receipt.status === 'success' ? 'tx:redeem_receipt' : 'tx:redeem_failed',
+          createTransactionProperties({
+            ...baseAnalyticsInput,
+            step: receipt.status === 'success' ? 'receipt' : 'failed',
+            txHash: receipt.transactionHash,
+            receiptStatus: receipt.status
+          })
+        );
+
+        return { receipt, amount };
+      } catch (err) {
+        const errorType = getAnalyticsErrorType(err);
+
+        analytics.capture(
+          errorType === 'user_rejected' ? 'tx:redeem_signature_rejected' : 'tx:redeem_failed',
+          createTransactionProperties({
+            ...baseAnalyticsInput,
+            step: errorType === 'user_rejected' ? 'signature_rejected' : 'failed',
+            txHash,
+            error_type: errorType
+          })
+        );
+
+        throw err;
+      }
     },
 
     onError: (err, variables) => {

--- a/apps/dapp/src/app/(dashboard)/home/deposit/_hooks/useRouterDeposit.ts
+++ b/apps/dapp/src/app/(dashboard)/home/deposit/_hooks/useRouterDeposit.ts
@@ -8,6 +8,8 @@ import { zivoeRouterAbi, zivoeTranchesAbi } from '@zivoe/contracts/abis';
 
 import { type DepositToken } from '@/types/constants';
 
+import { createTransactionProperties, getAnalyticsErrorType } from '@/lib/analytics/events';
+import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { depositDialogAtom, transactionAtom } from '@/lib/store';
 import { AppError, getDepositTransactionData, handleDepositRefetches, onTxError, skipTxSettled } from '@/lib/utils';
 
@@ -19,6 +21,7 @@ export type RouterDepositParams = WriteContractParameters<typeof zivoeRouterAbi,
 
 export const useRouterDeposit = () => {
   const { address } = useAccount();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const { simulateTx, sendTx, waitForTxReceipt, isTxPending } = useTx();
   const setTransaction = useSetAtom(transactionAtom);
@@ -28,6 +31,15 @@ export const useRouterDeposit = () => {
     mutationFn: async ({ stableCoinName, amount }: { stableCoinName: RouterDepositToken; amount?: bigint }) => {
       if (!amount || amount === 0n) throw new AppError({ message: 'No amount to deposit' });
 
+      const baseAnalyticsInput = {
+        flow: 'deposit',
+        step: 'submitted',
+        walletAddress: address,
+        tokenIn: stableCoinName,
+        tokenOut: 'zVLT',
+        amountInRaw: amount
+      } as const;
+
       const params: RouterDepositParams & SimulateContractParameters = {
         abi: zivoeRouterAbi,
         address: CONTRACTS.zRTR,
@@ -35,16 +47,46 @@ export const useRouterDeposit = () => {
         args: [CONTRACTS[stableCoinName], amount]
       };
 
-      await simulateTx(params);
+      let txHash: `0x${string}` | undefined;
 
-      const { hash } = await sendTx(params);
+      try {
+        await simulateTx(params);
 
-      const receipt = await waitForTxReceipt({
-        hash,
-        messages: { pending: `Depositing ${stableCoinName}...` }
-      });
+        const { hash } = await sendTx(params);
+        txHash = hash;
+        analytics.capture('tx:deposit_submitted', createTransactionProperties({ ...baseAnalyticsInput, txHash }));
 
-      return { receipt };
+        const receipt = await waitForTxReceipt({
+          hash,
+          messages: { pending: `Depositing ${stableCoinName}...` }
+        });
+
+        analytics.capture(
+          receipt.status === 'success' ? 'tx:deposit_receipt' : 'tx:deposit_failed',
+          createTransactionProperties({
+            ...baseAnalyticsInput,
+            step: receipt.status === 'success' ? 'receipt' : 'failed',
+            txHash: receipt.transactionHash,
+            receiptStatus: receipt.status
+          })
+        );
+
+        return { receipt };
+      } catch (err) {
+        const errorType = getAnalyticsErrorType(err);
+
+        analytics.capture(
+          errorType === 'user_rejected' ? 'tx:deposit_signature_rejected' : 'tx:deposit_failed',
+          createTransactionProperties({
+            ...baseAnalyticsInput,
+            step: errorType === 'user_rejected' ? 'signature_rejected' : 'failed',
+            txHash,
+            error_type: errorType
+          })
+        );
+
+        throw err;
+      }
     },
 
     onError: (err, variables) => {

--- a/apps/dapp/src/app/(dashboard)/home/deposit/_hooks/useRouterDepositPermit.ts
+++ b/apps/dapp/src/app/(dashboard)/home/deposit/_hooks/useRouterDepositPermit.ts
@@ -12,6 +12,8 @@ import { erc20PermitAbi, zivoeRouterAbi, zivoeTranchesAbi } from '@zivoe/contrac
 
 import { type DepositToken } from '@/types/constants';
 
+import { createTransactionProperties, getAnalyticsErrorType } from '@/lib/analytics/events';
+import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { depositDialogAtom, transactionAtom } from '@/lib/store';
 import {
   AppError,
@@ -30,6 +32,7 @@ export type RouterDepositPermitParams = WriteContractParameters<typeof zivoeRout
 
 export const useRouterDepositPermit = () => {
   const publicClient = usePublicClient();
+  const analytics = useAnalytics();
   const { data: walletClient } = useWalletClient({ query: { retry: 0, meta: { skipErrorToast: true } } });
   const queryClient = useQueryClient();
   const setTransaction = useSetAtom(transactionAtom);
@@ -45,12 +48,32 @@ export const useRouterDepositPermit = () => {
       if (!walletClient || !publicClient || !address) throw new AppError({ message: 'Client or address not found' });
       if (!amount || amount === 0n) throw new AppError({ message: 'No amount to deposit' });
 
+      const depositAnalyticsInput = {
+        flow: 'deposit',
+        step: 'submitted',
+        walletAddress: address,
+        tokenIn: stableCoinName,
+        tokenOut: 'zVLT',
+        amountInRaw: amount
+      } as const;
+
+      const permitAnalyticsInput = {
+        flow: 'permit',
+        step: 'started',
+        walletAddress: address,
+        tokenIn: stableCoinName,
+        amountInRaw: amount,
+        spender: CONTRACTS.zRTR
+      } as const;
+
       setIsPermitPending(true);
       const deadline = BigInt(Math.floor(Date.now() / 1000) + 600); // 10 minutes from now
 
       let signature: `0x${string}` | undefined;
 
       try {
+        analytics.capture('tx:permit_started', createTransactionProperties(permitAnalyticsInput));
+
         const nonce = await publicClient.readContract({
           address: CONTRACTS[stableCoinName],
           abi: erc20PermitAbi,
@@ -97,6 +120,20 @@ export const useRouterDepositPermit = () => {
         }
 
         signature = signResult.res;
+        analytics.capture('tx:permit_signed', createTransactionProperties({ ...permitAnalyticsInput, step: 'signed' }));
+      } catch (err) {
+        const errorType = getAnalyticsErrorType(err);
+
+        analytics.capture(
+          errorType === 'user_rejected' ? 'tx:permit_signature_rejected' : 'tx:permit_failed',
+          createTransactionProperties({
+            ...permitAnalyticsInput,
+            step: errorType === 'user_rejected' ? 'signature_rejected' : 'failed',
+            error_type: errorType
+          })
+        );
+
+        throw err;
       } finally {
         setIsPermitPending(false);
       }
@@ -114,16 +151,46 @@ export const useRouterDepositPermit = () => {
         args: [address, CONTRACTS[stableCoinName], amount, deadline, v, r, s]
       };
 
-      await simulateTx(params);
+      let txHash: `0x${string}` | undefined;
 
-      const { hash } = await sendTx(params);
+      try {
+        await simulateTx(params);
 
-      const receipt = await waitForTxReceipt({
-        hash,
-        messages: { pending: `Depositing ${stableCoinName}...` }
-      });
+        const { hash } = await sendTx(params);
+        txHash = hash;
+        analytics.capture('tx:deposit_submitted', createTransactionProperties({ ...depositAnalyticsInput, txHash }));
 
-      return { receipt };
+        const receipt = await waitForTxReceipt({
+          hash,
+          messages: { pending: `Depositing ${stableCoinName}...` }
+        });
+
+        analytics.capture(
+          receipt.status === 'success' ? 'tx:deposit_receipt' : 'tx:deposit_failed',
+          createTransactionProperties({
+            ...depositAnalyticsInput,
+            step: receipt.status === 'success' ? 'receipt' : 'failed',
+            txHash: receipt.transactionHash,
+            receiptStatus: receipt.status
+          })
+        );
+
+        return { receipt };
+      } catch (err) {
+        const errorType = getAnalyticsErrorType(err);
+
+        analytics.capture(
+          errorType === 'user_rejected' ? 'tx:deposit_signature_rejected' : 'tx:deposit_failed',
+          createTransactionProperties({
+            ...depositAnalyticsInput,
+            step: errorType === 'user_rejected' ? 'signature_rejected' : 'failed',
+            txHash,
+            error_type: errorType
+          })
+        );
+
+        throw err;
+      }
     },
 
     onError: (err, variables) =>

--- a/apps/dapp/src/app/(dashboard)/home/deposit/_hooks/useVaultDeposit.ts
+++ b/apps/dapp/src/app/(dashboard)/home/deposit/_hooks/useVaultDeposit.ts
@@ -8,6 +8,8 @@ import { zivoeRewardsAbi, zivoeVaultAbi } from '@zivoe/contracts/abis';
 
 import { type DepositToken } from '@/types/constants';
 
+import { createTransactionProperties, getAnalyticsErrorType } from '@/lib/analytics/events';
+import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { depositDialogAtom, transactionAtom } from '@/lib/store';
 import { AppError, getDepositTransactionData, handleDepositRefetches, onTxError, skipTxSettled } from '@/lib/utils';
 
@@ -19,6 +21,7 @@ export type VaultDepositParams = WriteContractParameters<typeof zivoeVaultAbi, '
 
 export const useVaultDeposit = () => {
   const { address } = useAccount();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const { simulateTx, sendTx, waitForTxReceipt, isTxPending } = useTx();
   const setTransaction = useSetAtom(transactionAtom);
@@ -29,6 +32,15 @@ export const useVaultDeposit = () => {
       if (!address) throw new AppError({ message: 'Wallet not connected' });
       if (!amount || amount === 0n) throw new AppError({ message: 'No amount to deposit' });
 
+      const baseAnalyticsInput = {
+        flow: 'deposit',
+        step: 'submitted',
+        walletAddress: address,
+        tokenIn: stableCoinName,
+        tokenOut: 'zVLT',
+        amountInRaw: amount
+      } as const;
+
       const params: VaultDepositParams & SimulateContractParameters = {
         abi: zivoeVaultAbi,
         address: CONTRACTS.zVLT,
@@ -36,16 +48,46 @@ export const useVaultDeposit = () => {
         args: [amount, address]
       };
 
-      await simulateTx(params);
+      let txHash: `0x${string}` | undefined;
 
-      const { hash } = await sendTx(params);
+      try {
+        await simulateTx(params);
 
-      const receipt = await waitForTxReceipt({
-        hash,
-        messages: { pending: `Depositing ${stableCoinName}...` }
-      });
+        const { hash } = await sendTx(params);
+        txHash = hash;
+        analytics.capture('tx:deposit_submitted', createTransactionProperties({ ...baseAnalyticsInput, txHash }));
 
-      return { receipt };
+        const receipt = await waitForTxReceipt({
+          hash,
+          messages: { pending: `Depositing ${stableCoinName}...` }
+        });
+
+        analytics.capture(
+          receipt.status === 'success' ? 'tx:deposit_receipt' : 'tx:deposit_failed',
+          createTransactionProperties({
+            ...baseAnalyticsInput,
+            step: receipt.status === 'success' ? 'receipt' : 'failed',
+            txHash: receipt.transactionHash,
+            receiptStatus: receipt.status
+          })
+        );
+
+        return { receipt };
+      } catch (err) {
+        const errorType = getAnalyticsErrorType(err);
+
+        analytics.capture(
+          errorType === 'user_rejected' ? 'tx:deposit_signature_rejected' : 'tx:deposit_failed',
+          createTransactionProperties({
+            ...baseAnalyticsInput,
+            step: errorType === 'user_rejected' ? 'signature_rejected' : 'failed',
+            txHash,
+            error_type: errorType
+          })
+        );
+
+        throw err;
+      }
     },
 
     onError: (err, variables) => {

--- a/apps/dapp/src/app/(dashboard)/home/deposit/deposit-flow.tsx
+++ b/apps/dapp/src/app/(dashboard)/home/deposit/deposit-flow.tsx
@@ -17,6 +17,8 @@ import { Select, SelectItem, SelectListBox, SelectPopover, SelectTrigger, Select
 
 import { DEPOSIT_TOKENS, DEPOSIT_TOKEN_DECIMALS, type DepositToken } from '@/types/constants';
 
+import { createTransactionProperties } from '@/lib/analytics/events';
+import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { customNumber, formatBigIntToReadable } from '@/lib/utils';
 
 import { useAccount } from '@/hooks/useAccount';
@@ -46,6 +48,7 @@ export function DepositFlow({ apy }: { apy: number | null }) {
   const [receive, setReceive] = useState<string | undefined>(undefined);
 
   const account = useAccount();
+  const analytics = useAnalytics();
   const chainalysis = useChainalysis();
 
   const allowances = useDepositAllowances();
@@ -147,6 +150,19 @@ export function DepositFlow({ apy }: { apy: number | null }) {
   const handleDeposit = async ({ token }: { token: DepositToken }) => {
     const isValid = await validateForm();
     if (!isValid) return;
+
+    analytics.capture(
+      'tx:deposit_started',
+      createTransactionProperties({
+        flow: 'deposit',
+        step: 'started',
+        walletAddress: account.address,
+        tokenIn: token,
+        tokenOut: 'zVLT',
+        amountInRaw: depositRaw,
+        amountOutRaw: receive ? parseUnits(receive, 18) : undefined
+      })
+    );
 
     if (token === 'USDT')
       routerDeposit.mutate({ stableCoinName: token, amount: depositRaw }, { onSuccess: handleDepositSuccess });

--- a/apps/dapp/src/app/(dashboard)/home/deposit/redeem-flow.tsx
+++ b/apps/dapp/src/app/(dashboard)/home/deposit/redeem-flow.tsx
@@ -12,6 +12,8 @@ import { CONTRACTS } from '@zivoe/contracts';
 import { Button } from '@zivoe/ui/core/button';
 import { Input } from '@zivoe/ui/core/input';
 
+import { createTransactionProperties } from '@/lib/analytics/events';
+import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { formatBigIntWithCommas } from '@/lib/utils';
 
 import { useAccount } from '@/hooks/useAccount';
@@ -43,6 +45,7 @@ export default function RedeemFlow() {
   const [receive, setReceive] = useState<Receive>({ value: undefined, fee: undefined });
 
   const account = useAccount();
+  const analytics = useAnalytics();
   const chainalysis = useChainalysis();
 
   const liquidity = useAvailableLiquidity();
@@ -149,6 +152,19 @@ export default function RedeemFlow() {
   const handleRedeem = async () => {
     const isValid = await validateForm();
     if (!isValid) return;
+
+    analytics.capture(
+      'tx:redeem_started',
+      createTransactionProperties({
+        flow: 'redeem',
+        step: 'started',
+        walletAddress: account.address,
+        tokenIn: 'zVLT',
+        tokenOut: 'USDC',
+        amountInRaw: redeemRaw,
+        amountOutRaw: receive.value ? parseUnits(receive.value, 6) : undefined
+      })
+    );
 
     redeemUSDC.mutate({ amount: redeemRaw }, { onSuccess: handleRedeemSuccess });
   };

--- a/apps/dapp/src/app/api/auth/post-signin/route.ts
+++ b/apps/dapp/src/app/api/auth/post-signin/route.ts
@@ -4,5 +4,7 @@ import { getOnboardedStatus } from '@/server/data/auth';
 
 export async function GET(request: NextRequest) {
   const { isOnboarded } = await getOnboardedStatus();
-  return NextResponse.redirect(new URL(isOnboarded ? '/' : '/onboarding', request.url));
+  const destination = isOnboarded ? '/' : '/onboarding';
+
+  return NextResponse.redirect(new URL(destination, request.url));
 }

--- a/apps/dapp/src/app/api/monitor/deposits/route.ts
+++ b/apps/dapp/src/app/api/monitor/deposits/route.ts
@@ -8,6 +8,7 @@ import { deposit as depositTable } from '@/server/clients/ponder/schema';
 import { getWeb3Client } from '@/server/clients/web3';
 import { isEmailPreferenceEnabled } from '@/server/data/email-preferences';
 import { getEventsAfterCursor } from '@/server/data/ponder';
+import { captureServerEvent } from '@/server/utils/analytics';
 import {
   createCronRunWideEvent,
   getErrorMessage,
@@ -31,6 +32,7 @@ import {
 import type { FailureContext, MonitorCursor } from '@/server/utils/transaction-notifications';
 
 import { withQstashSignature } from '@/lib/qstash';
+import { createTransactionProperties } from '@/lib/analytics/events';
 import { ApiError, escapeHtml, formatBigIntWithCommas, handlePromise, withErrorHandler } from '@/lib/utils';
 
 import { env } from '@/env';
@@ -165,6 +167,32 @@ const handler = async (req: NextRequest): ApiResponse<string> => {
       runEvent.stage = 'get_users';
       const users = await getUsersForWallet(deposit.accountId);
       const telegramEmailLine = formatTelegramEmailLine(users);
+
+      await Promise.all(
+        users.map((userRecord) =>
+          captureServerEvent({
+            distinctId: userRecord.userId,
+            event: 'tx:deposit_confirmed',
+            timestamp: new Date(Number(deposit.timestamp) * 1000),
+            properties: {
+              ...createTransactionProperties({
+                flow: 'deposit',
+                step: 'confirmed',
+                walletAddress: deposit.accountId,
+                tokenIn: inputDetails.tokenSymbol,
+                tokenOut: 'zVLT',
+                amountInRaw: inputDetails.amountRaw,
+                amountOutRaw: deposit.shares,
+                txHash: deposit.txHash,
+                blockNumber: deposit.blockNumber,
+                logIndex: deposit.logIndex,
+                eventId: deposit.id
+              }),
+              $insert_id: `tx:deposit_confirmed:${deposit.id}:${userRecord.userId}`
+            }
+          })
+        )
+      );
 
       telegramItems.push(
         `<b>Deposit</b>\nUser: ${deposit.accountId}\n${telegramEmailLine}\nInput: ${escapeHtml(

--- a/apps/dapp/src/app/api/monitor/redemptions/route.ts
+++ b/apps/dapp/src/app/api/monitor/redemptions/route.ts
@@ -6,6 +6,7 @@ import { redemption as redemptionTable } from '@/server/clients/ponder/schema';
 import { getWeb3Client } from '@/server/clients/web3';
 import { isEmailPreferenceEnabled } from '@/server/data/email-preferences';
 import { getEventsAfterCursor } from '@/server/data/ponder';
+import { captureServerEvent } from '@/server/utils/analytics';
 import {
   createCronRunWideEvent,
   getErrorMessage,
@@ -28,6 +29,7 @@ import {
 import type { FailureContext, MonitorCursor } from '@/server/utils/transaction-notifications';
 
 import { withQstashSignature } from '@/lib/qstash';
+import { createTransactionProperties } from '@/lib/analytics/events';
 import { ApiError, escapeHtml, formatBigIntWithCommas, handlePromise, withErrorHandler } from '@/lib/utils';
 
 import { env } from '@/env';
@@ -110,6 +112,32 @@ const handler = async (req: NextRequest): ApiResponse<string> => {
       runEvent.stage = 'get_users';
       const users = await getUsersForWallet(redemption.accountId);
       const telegramEmailLine = formatTelegramEmailLine(users);
+
+      await Promise.all(
+        users.map((userRecord) =>
+          captureServerEvent({
+            distinctId: userRecord.userId,
+            event: 'tx:redeem_confirmed',
+            timestamp: new Date(Number(redemption.timestamp) * 1000),
+            properties: {
+              ...createTransactionProperties({
+                flow: 'redeem',
+                step: 'confirmed',
+                walletAddress: redemption.accountId,
+                tokenIn: 'zVLT',
+                tokenOut: 'USDC',
+                amountInRaw: redemption.zVLTBurned,
+                amountOutRaw: redemption.usdcRedeemed,
+                txHash: redemption.txHash,
+                blockNumber: redemption.blockNumber,
+                logIndex: redemption.logIndex,
+                eventId: redemption.id
+              }),
+              $insert_id: `tx:redeem_confirmed:${redemption.id}:${userRecord.userId}`
+            }
+          })
+        )
+      );
 
       telegramItems.push(
         `<b>Redeem</b>\nUser: ${redemption.accountId}\n${telegramEmailLine}\nzVLT burned: ${escapeHtml(

--- a/apps/dapp/src/hooks/useApproveSpending.ts
+++ b/apps/dapp/src/hooks/useApproveSpending.ts
@@ -9,6 +9,8 @@ import { type tetherTokenAbi, type zivoeTrancheTokenAbi } from '@zivoe/contracts
 
 import { type Token } from '@/types/constants';
 
+import { createTransactionProperties, getAnalyticsErrorType } from '@/lib/analytics/events';
+import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { queryKeys } from '@/lib/query-keys';
 import { type TransactionData } from '@/lib/store';
 import { transactionAtom } from '@/lib/store';
@@ -22,6 +24,7 @@ export type ApproveTokenParams = WriteContractParameters<ApproveTokenAbi, 'appro
 
 export const useApproveSpending = () => {
   const { address } = useAccount();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const { simulateTx, sendTx, waitForTxReceipt, isTxPending } = useTx();
   const setTransaction = useSetAtom(transactionAtom);
@@ -46,6 +49,17 @@ export const useApproveSpending = () => {
     }) => {
       if (!amount || amount === 0n) throw new AppError({ message: 'No amount to approve' });
 
+      const baseAnalyticsInput = {
+        flow: 'approval',
+        step: 'started',
+        walletAddress: address,
+        tokenIn: name as Token,
+        amountInRaw: amount,
+        spender
+      } as const;
+
+      analytics.capture('tx:approval_started', createTransactionProperties(baseAnalyticsInput));
+
       const params: ApproveTokenParams & SimulateContractParameters = {
         abi,
         address: contract,
@@ -56,21 +70,57 @@ export const useApproveSpending = () => {
       await simulateTx(params);
 
       const { hash } = await sendTx(params);
+      analytics.capture(
+        'tx:approval_submitted',
+        createTransactionProperties({
+          ...baseAnalyticsInput,
+          flow: 'approval',
+          step: 'submitted',
+          txHash: hash
+        })
+      );
 
       const receipt = await waitForTxReceipt({
         hash,
         messages: { pending: `Approving ${name}...` }
       });
 
+      analytics.capture(
+        receipt.status === 'success' ? 'tx:approval_confirmed' : 'tx:approval_failed',
+        createTransactionProperties({
+          ...baseAnalyticsInput,
+          flow: 'approval',
+          step: receipt.status === 'success' ? 'confirmed' : 'failed',
+          txHash: receipt.transactionHash,
+          receiptStatus: receipt.status
+        })
+      );
+
       return { receipt, successMessage, errorMessage };
     },
 
-    onError: (err, { abi: _abi, ...variables }) =>
+    onError: (err, { abi: _abi, ...variables }) => {
+      const errorType = getAnalyticsErrorType(err);
+
+      analytics.capture(
+        errorType === 'user_rejected' ? 'tx:approval_signature_rejected' : 'tx:approval_failed',
+        createTransactionProperties({
+          flow: 'approval',
+          step: errorType === 'user_rejected' ? 'signature_rejected' : 'failed',
+          walletAddress: address,
+          tokenIn: variables.name as Token,
+          amountInRaw: variables.amount,
+          spender: variables.spender,
+          error_type: errorType
+        })
+      );
+
       onTxError({
         err,
         defaultToastMsg: `Error Approving ${variables.name}`,
         sentry: { flow: 'approve', extras: variables }
-      }),
+      });
+    },
 
     onSuccess: ({ receipt }, { name, abi, successMessage, errorMessage }) => {
       let meta: TransactionData['meta'] = undefined;

--- a/apps/dapp/src/lib/analytics/events.ts
+++ b/apps/dapp/src/lib/analytics/events.ts
@@ -1,0 +1,93 @@
+import { mainnet } from 'viem/chains';
+
+import { type DepositToken, type Token } from '@/types/constants';
+
+export type AnalyticsEvent =
+  | 'auth:sign-up'
+  | 'auth:otp_requested'
+  | 'auth:otp_resent'
+  | 'onboarding:completed'
+  | 'onboarding:started'
+  | 'wallet_connected'
+  | 'tx:deposit_started'
+  | 'tx:deposit_signature_rejected'
+  | 'tx:deposit_submitted'
+  | 'tx:deposit_receipt'
+  | 'tx:deposit_failed'
+  | 'tx:deposit_confirmed'
+  | 'tx:redeem_started'
+  | 'tx:redeem_signature_rejected'
+  | 'tx:redeem_submitted'
+  | 'tx:redeem_receipt'
+  | 'tx:redeem_failed'
+  | 'tx:redeem_confirmed'
+  | 'tx:approval_started'
+  | 'tx:approval_signature_rejected'
+  | 'tx:approval_submitted'
+  | 'tx:approval_confirmed'
+  | 'tx:approval_failed'
+  | 'tx:permit_started'
+  | 'tx:permit_signature_rejected'
+  | 'tx:permit_signed'
+  | 'tx:permit_failed';
+
+export type AnalyticsProperties = Record<
+  string,
+  string | number | boolean | null | undefined | Array<string | number | boolean>
+>;
+
+type TransactionFlow = 'deposit' | 'redeem' | 'approval' | 'permit';
+
+type TransactionAnalyticsInput = {
+  flow: TransactionFlow;
+  step: string;
+  walletAddress?: string | null;
+  chainId?: number;
+  tokenIn?: DepositToken | Token | 'USDC' | 'zVLT' | null;
+  tokenOut?: DepositToken | Token | 'USDC' | 'zVLT' | null;
+  amountInRaw?: bigint | string | number | null;
+  amountOutRaw?: bigint | string | number | null;
+  spender?: string | null;
+  txHash?: string | null;
+  blockNumber?: bigint | string | number | null;
+  logIndex?: number | null;
+  eventId?: string | null;
+  receiptStatus?: string | null;
+  error_type?: string | null;
+};
+
+function toAnalyticsAmount(value: bigint | string | number | null | undefined) {
+  if (value === null || value === undefined) return undefined;
+  return String(value);
+}
+
+export function compactAnalyticsProperties(properties: AnalyticsProperties): AnalyticsProperties {
+  return Object.fromEntries(Object.entries(properties).filter(([, value]) => value !== undefined));
+}
+
+export function createTransactionProperties(input: TransactionAnalyticsInput): AnalyticsProperties {
+  return {
+    flow: input.flow,
+    step: input.step,
+    wallet_address: input.walletAddress?.toLowerCase(),
+    chain_id: input.chainId ?? mainnet.id,
+    token_in: input.tokenIn ?? undefined,
+    token_out: input.tokenOut ?? undefined,
+    amount_in_raw: toAnalyticsAmount(input.amountInRaw),
+    amount_out_raw: toAnalyticsAmount(input.amountOutRaw),
+    spender: input.spender?.toLowerCase(),
+    tx_hash: input.txHash?.toLowerCase(),
+    block_number: toAnalyticsAmount(input.blockNumber),
+    log_index: input.logIndex ?? undefined,
+    event_id: input.eventId ?? undefined,
+    receipt_status: input.receiptStatus ?? undefined,
+    error_type: input.error_type ?? undefined
+  };
+}
+
+export function getAnalyticsErrorType(error: unknown) {
+  if (error instanceof Error && error.message.includes('Transaction rejected')) return 'user_rejected';
+  if (error instanceof Error && error.message.includes('User rejected the request')) return 'user_rejected';
+  if (error instanceof Error && error.message.includes('Simulation error')) return 'simulation_failed';
+  return 'failed';
+}

--- a/apps/dapp/src/lib/analytics/use-analytics.ts
+++ b/apps/dapp/src/lib/analytics/use-analytics.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { usePostHog } from 'posthog-js/react';
+
+import { env } from '@/env';
+
+import { type AnalyticsEvent, type AnalyticsProperties, compactAnalyticsProperties } from './events';
+
+export function useAnalytics() {
+  const posthog = usePostHog();
+
+  const capture = useCallback(
+    (event: AnalyticsEvent, properties: AnalyticsProperties = {}) => {
+      if (env.NEXT_PUBLIC_ENV !== 'production') return;
+      posthog.capture(event, compactAnalyticsProperties(properties));
+    },
+    [posthog]
+  );
+
+  return { capture };
+}

--- a/apps/dapp/src/server/actions/onboarding.ts
+++ b/apps/dapp/src/server/actions/onboarding.ts
@@ -94,6 +94,15 @@ export async function completeOnboarding(data: OnboardingFormData) {
         distinctId: session.user.id,
         event: 'onboarding:completed',
         properties: {
+          account_type: rest.accountType,
+          amount_of_interest: rest.amountOfInterest,
+          how_found_zivoe: rest.howFoundZivoe,
+          country:
+            rest.accountType === 'individual'
+              ? rest.countryOfResidence
+              : rest.accountType === 'organization'
+                ? rest.countryOfIncorporation
+                : undefined,
           $set: { ...rest, authId: id, name: `${firstName} ${lastName}` }
         }
       })

--- a/apps/dapp/src/server/actions/track-wallet-connection.ts
+++ b/apps/dapp/src/server/actions/track-wallet-connection.ts
@@ -6,10 +6,10 @@ import { sql } from 'drizzle-orm';
 import { isAddress } from 'viem';
 
 import { authDb } from '@/server/clients/auth-db';
-import { posthog } from '@/server/clients/posthog';
 import { qstash } from '@/server/clients/qstash';
 import { redis } from '@/server/clients/redis';
 import { walletConnection } from '@/server/db/schema';
+import { captureServerEvent } from '@/server/utils/analytics';
 import { BASE_URL } from '@/server/utils/base-url';
 
 import { QSTASH_JOB_LABELS, getQstashFailureCallback } from '@/lib/qstash';
@@ -88,7 +88,7 @@ export async function trackWalletConnection(wallet: { address: string; walletTyp
       failureCallback: getQstashFailureCallback(BASE_URL),
       label: QSTASH_JOB_LABELS.walletFetchHoldings
     }),
-    posthog.captureImmediate({
+    captureServerEvent({
       distinctId: user.id,
       event: 'wallet_connected',
       properties: {

--- a/apps/dapp/src/server/utils/analytics.ts
+++ b/apps/dapp/src/server/utils/analytics.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+import * as Sentry from '@sentry/nextjs';
+
+import { type AnalyticsEvent, type AnalyticsProperties, compactAnalyticsProperties } from '@/lib/analytics/events';
+
+import { env } from '@/env';
+
+import { posthog } from '../clients/posthog';
+
+export async function captureServerEvent({
+  distinctId,
+  event,
+  properties = {},
+  timestamp
+}: {
+  distinctId: string;
+  event: AnalyticsEvent;
+  properties?: AnalyticsProperties;
+  timestamp?: Date;
+}) {
+  if (env.NEXT_PUBLIC_ENV !== 'production') return;
+
+  try {
+    await posthog.captureImmediate({
+      distinctId,
+      event,
+      properties: compactAnalyticsProperties(properties),
+      timestamp
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { source: 'SERVER', flow: 'posthog-capture' },
+      extra: { distinctId, event }
+    });
+  }
+}


### PR DESCRIPTION
Summary
- Adds production-only PostHog helpers for client and server event capture.
- Tracks auth, onboarding, wallet connection, approval, permit, deposit, and redemption events.
- Sends confirmed deposit and redemption events from monitor routes with stable insert IDs.
